### PR TITLE
Fix when texture name doesn't exist or when material is blank string.

### DIFF
--- a/texture_manager.py
+++ b/texture_manager.py
@@ -196,7 +196,10 @@ class TextureManager():
         if not hasattr(o, 'Shape') or o.Shape is None or o.Shape.isNull():
             return False
         
-        if not hasattr(o, 'Material') or o.Material is None:
+        if not hasattr(o, 'Material') or o.Material is None or o.Material == '':
+            return False
+
+        if not hasattr(o.Material, 'Name') or o.Material.Name is None or o.Material.Name == '':
             return False
 
         return o.ViewObject.Visibility


### PR DESCRIPTION
Fix for https://github.com/furti/FreeCAD-ArchTextures/issues/36