### PR TITLE
Python 3.9 removed encoding from json.JSONDecoder

### DIFF
--- a/texture_manager.py
+++ b/texture_manager.py
@@ -54,7 +54,7 @@ class TextureManager():
         else:
             try:
                 self.textureData = json.load(
-                    fileObject, encoding='utf-8', cls=TextureConfigDecoder)
+                    fileObject, cls=TextureConfigDecoder)
             finally:
                 fileObject.close()
 
@@ -82,7 +82,7 @@ class TextureManager():
 
     def deserializeTextureData(self, textureDataAsString):
         self.textureData = json.loads(
-            textureDataAsString, encoding='utf-8', cls=TextureConfigDecoder)
+            textureDataAsString, cls=TextureConfigDecoder)
 
     def textureObjects(self, debug=False):
         # Make sure that no old textures are left. Otherwise we could end up with duplicate textures


### PR DESCRIPTION
Fix for https://github.com/furti/FreeCAD-ArchTextures/issues/39